### PR TITLE
Adds restriction that programmatic bindings cannot be generic

### DIFF
--- a/plugins/nominal-connection-checker/src/type_structure.js
+++ b/plugins/nominal-connection-checker/src/type_structure.js
@@ -46,6 +46,42 @@ export class TypeStructure {
           return param.equals(otherStructure.params[i]);
         });
   }
+
+  /**
+   * Returns true if the callback returns true for at least one type name
+   * (generic or otherwise) contained within this type structure.
+   * @param {function(string): boolean} callback A function to test for each
+   *     type name in this type structure.
+   * @param {Object=} thisArg An option value to use as `this` when executing
+   *     the callback.
+   * @return {boolean} True if the callback returns true for at least one type
+   *     name (generic or otherwise) contained within this type structure.
+   */
+  someName(callback, thisArg = undefined) {
+    if (callback.call(thisArg, this.name)) {
+      return true;
+    }
+    // Handles early returns.
+    return this.params.some((param) => param.someName(callback, thisArg));
+  }
+
+  /**
+   * Returns true if the callback returns true for every type name (generic or
+   * otherwise) contained within this type structure.
+   * @param {function(string): boolean} callback A function to test for each
+   *     type name in this type structure.
+   * @param {Object=} thisArg An option value to use as `this` when executing
+   *     the callback.
+   * @return {boolean} True if the callback returns true for every type name
+   *     (generic or otherwise) contained within this type structure.
+   */
+  everyName(callback, thisArg = undefined) {
+    if (!callback.call(thisArg, this.name)) {
+      return false;
+    }
+    // Handles early returns.
+    return this.params.every((param) => param.everyName(callback, thisArg));
+  }
 }
 
 /**

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -1905,6 +1905,39 @@ suite('NominalConnectionChecker', function() {
   });
 
   suite('bindType', function() {
+    suite('Valid and invalid types', function() {
+      setup(function() {
+        const block = this.workspace.newBlock('static_t_main_out_value');
+
+        this.assertThrows = function(type) {
+          chai.assert.throws(() => {
+            this.checker.bindType(block, 't', type);
+          }, Error);
+        };
+        this.assertDoesNotThrow = function(type) {
+          chai.assert.doesNotThrow(() => {
+            this.checker.bindType(block, 't', type);
+          }, Error);
+        };
+      });
+
+      test('Explicit', function() {
+        this.assertDoesNotThrow('typea');
+      });
+
+      test('Explicit parameters', function() {
+        this.assertDoesNotThrow('typea[typeb, typec[typed]]');
+      });
+
+      test('Generic', function() {
+        this.assertThrows('g');
+      });
+
+      test('Generic parameters', function() {
+        this.assertThrows('typea[typeb, typec[g]]');
+      });
+    });
+
     suite('Disconnect connections', function() {
       setup(function() {
         this.assertIsConnected = function(conn) {

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -785,7 +785,6 @@ suite('NominalConnectionChecker', function() {
           t2.in1.connect(typeCOut);
           t2.in2.connect(typeDOut);
 
-          console.log('asserting');
           this.assertCanConnect(t.in2, t2.out);
         });
 
@@ -3349,7 +3348,6 @@ suite('NominalConnectionChecker', function() {
               }
 
               // Without proper filtering this could be ['typeb', 'typea'].
-              console.log('asserting');
               this.assertHasType(t1.out, ['typeb']);
             });
 

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -1901,6 +1901,28 @@ suite('NominalConnectionChecker', function() {
           });
 
       runThreeBlockTests();
+
+      clearSiblingTests();
+
+      siblingTest('Insert between', function() {
+        const t = this.getMain('t');
+        const listT1 = this.getMain('list[t]');
+        const listT2 = this.getMain('list[t]');
+        const listT3 = this.getMain('list[t]');
+        const dogOut1 = this.getInnerOutput('dog');
+        const dogOut2 = this.getInnerOutput('dog');
+
+        t.in1.connect(listT1.out);
+        t.in2.connect(listT2.out);
+        listT1.in1.connect(dogOut1);
+        listT2.in1.connect(dogOut2);
+
+        t.in2.connect(listT3.out);
+        this.assertCanConnect(listT3.in1, listT2.out);
+        listT3.in1.connect(listT2.out);
+      });
+
+      runSiblingTests();
     });
   });
 

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -2518,25 +2518,6 @@ suite('NominalConnectionChecker', function() {
         this.assertHasType(main.in1, 'dog');
       });
 
-      // TODO: Broken due to unification being broken.
-      siblingTest.skip('Removing duplicates', function() {
-        const main = this.getMain('dicttovalue');
-        const main2 = this.getMain('typestodict');
-        const main3 = this.getMain('t');
-        // Cat and dog should have two parents for this test, but removed
-        // temporarily to not break other tests.
-        const dogOut = this.getInnerOutput('dog');
-        const catOut = this.getInnerOutput('cat');
-        const catOut2 = this.getInnerOutput('cat');
-        main.in1.connect(main2.out);
-        main2.in1.connect(main3.out);
-        main2.in2.connect(catOut);
-        main3.in1.connect(dogOut);
-        main3.in2.connect(catOut2);
-
-        this.assertBlockHasType(main.block, 'v', 'cat');
-      });
-
       runSiblingTests();
 
       suite('Parent explicit', function() {

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -1528,7 +1528,6 @@ suite('Hierarchy Validation', function() {
     const conflictMsg = 'The param name %s in %s conflicts with the ' +
         'param(s) [%s]';
     test('Param conflicts once', function() {
-      this.errorStub.callsFake((...params) => console.log(params));
       validateHierarchy({
         'typeA': {
           'params': [

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -10296,7 +10296,6 @@ suite('TypeHierarchy', function() {
               },
               'typeD': { },
             });
-            console.log('asserting');
             this.assertNoNearestCommonDescendants(
                 hierarchy,
                 ['typeC[typeD]', 'typeA[typeD, typeD]']);

--- a/plugins/nominal-connection-checker/test/type_structure_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_structure_test.mocha.js
@@ -493,4 +493,66 @@ suite('TypeStructure', function() {
           'typeA[typeA[typeA[typeA[typeA]]]]');
     });
   });
+
+  suite('someName', function() {
+    test('True', function() {
+      const type = parseType('typea');
+      chai.assert.isTrue(type.someName((name) => name == 'typea'));
+    });
+
+    test('True in params', function() {
+      const type = parseType('typeb[typeb, typeb[typea]]');
+      chai.assert.isTrue(type.someName((name) => name == 'typea'));
+    });
+
+    test('True multiple times', function() {
+      const type = parseType('typeb[typea, typea]');
+      chai.assert.isTrue(type.someName((name) => name == 'typea'));
+    });
+
+    test('False', function() {
+      const type = parseType('typeb[typeb, typeb]');
+      chai.assert.isFalse(type.someName((name) => name == 'typea'));
+    });
+
+    test('thisArg', function() {
+      const obj = {name: 'typea'};
+      const type = parseType('typeb[typeb, typeb[typea]]');
+      const func = function(name) {
+        return name == this.name;
+      };
+      chai.assert.isTrue(type.someName(func, obj));
+    });
+  });
+
+  suite('everyName', function() {
+    test('True', function() {
+      const type = parseType('typea[typea, typea]');
+      chai.assert.isTrue(type.everyName((name) => name == 'typea'));
+    });
+
+    test('False', function() {
+      const type = parseType('typeb');
+      chai.assert.isFalse(type.everyName((name) => name == 'typea'));
+    });
+
+    test('False in params', function() {
+      const type = parseType('typea[typea, typea[typeb]]');
+      chai.assert.isFalse(type.everyName((name) => name == 'typea'));
+    });
+
+    test('False multiple times', function() {
+      const type = parseType('typea[typeb, typeb]');
+      chai.assert.isFalse(type.everyName((name) => name == 'typea'));
+    });
+
+    test('thisArg', function() {
+      const obj = {name: 'typea'};
+      const type = parseType('typea[typea, typea[typea]]');
+      const func = function(name) {
+        return name == this.name;
+      };
+      chai.assert.isTrue(type.everyName(func, obj));
+    });
+  });
 });


### PR DESCRIPTION
### Description

Adds restriction that programmatic bindings cannot be generic, with errors and all that nice stuff.

### Testing

Tests that generics and generic parameterized types are not accepted.